### PR TITLE
update: limit reasoning_effort to gpt-oss & refine SAFETY_PATTERNS

### DIFF
--- a/src/oscar/cli/main.py
+++ b/src/oscar/cli/main.py
@@ -33,38 +33,38 @@ def display_welcome():
     active_config = settings.get_active_llm_config()
     
     config_info = f"""
-[bold]Configuration:[/bold]
-• LLM Provider: [green]{active_provider}[/green]
-• Model: [cyan]{active_config.model}[/cyan]
-• Safe Mode: [{'green' if settings.safe_mode else 'red'}]{settings.safe_mode}[/]
-• Debug Mode: [{'yellow' if settings.debug_mode else 'dim'}]{settings.debug_mode}[/]
-"""
+        [bold]Configuration:[/bold]
+        • LLM Provider: [green]{active_provider}[/green]
+        • Model: [cyan]{active_config.model}[/cyan]
+        • Safe Mode: [{'green' if settings.safe_mode else 'red'}]{settings.safe_mode}[/]
+        • Debug Mode: [{'yellow' if settings.debug_mode else 'dim'}]{settings.debug_mode}[/]
+        """
     console.print(config_info)
 
 
 def display_help():
     """Display available commands."""
     help_text = """
-[bold]Available Commands:[/bold]
-• [cyan]help[/cyan] or [cyan]?[/cyan] - Show this help
-• [cyan]config[/cyan] - Show configuration details
-• [cyan]test[/cyan] - Test LLM connection
-• [cyan]test-agent[/cyan] - Test all components
-• [cyan]quit[/cyan] or [cyan]exit[/cyan] - Exit OSCAR
+        [bold]Available Commands:[/bold]
+        • [cyan]help[/cyan] or [cyan]?[/cyan] - Show this help
+        • [cyan]config[/cyan] - Show configuration details
+        • [cyan]test[/cyan] - Test LLM connection
+        • [cyan]test-agent[/cyan] - Test all components
+        • [cyan]quit[/cyan] or [cyan]exit[/cyan] - Exit OSCAR
 
-[bold]Natural Language Usage:[/bold]
-Just type your request in plain English:
-• "Create a new Python project"
-• "Download the latest Python installer"
-• "List files in current directory"
-• "Search for machine learning tutorials"
+        [bold]Natural Language Usage:[/bold]
+        Just type your request in plain English:
+        • "Create a new Python project"
+        • "Download the latest Python installer"
+        • "List files in current directory"
+        • "Search for machine learning tutorials"
 
-[bold]Safety Features:[/bold]
-• All actions require confirmation
-• Dangerous commands need extra approval
-• Complete audit logging
-• Dry-run mode available (use --dry-run)
-"""
+        [bold]Safety Features:[/bold]
+        • All actions require confirmation
+        • Dangerous commands need extra approval
+        • Complete audit logging
+        • Dry-run mode available (use --dry-run)
+        """
     console.print(help_text)
 
 
@@ -72,6 +72,7 @@ Just type your request in plain English:
 @click.option('--debug', is_flag=True, help='Enable debug mode')
 @click.option('--dry-run', is_flag=True, help='Enable dry-run mode')
 @click.option('--config-check', is_flag=True, help='Check configuration and exit')
+
 def main(debug, dry_run, config_check):
     """OSCAR - Operating System's Complete Agentic Rex"""
     
@@ -149,23 +150,23 @@ def show_config():
     active_config = settings.get_active_llm_config()
     
     config_details = f"""
-[bold]OSCAR Configuration:[/bold]
+        [bold]OSCAR Configuration:[/bold]
 
-[bold]LLM Settings:[/bold]
-• Provider: [green]{active_provider}[/green]
-• Model: [cyan]{active_config.model}[/cyan]
-• Max Tokens: [yellow]{active_config.max_tokens}[/yellow]
-• Temperature: [yellow]{active_config.temperature}[/yellow]
+        [bold]LLM Settings:[/bold]
+        • Provider: [green]{active_provider}[/green]
+        • Model: [cyan]{active_config.model}[/cyan]
+        • Max Tokens: [yellow]{active_config.max_tokens}[/yellow]
+        • Temperature: [yellow]{active_config.temperature}[/yellow]
 
-[bold]System Settings:[/bold]
-• Safe Mode: [{'green' if settings.safe_mode else 'red'}]{settings.safe_mode}[/]
-• Debug Mode: [{'yellow' if settings.debug_mode else 'dim'}]{settings.debug_mode}[/]
-• Dry Run: [{'yellow' if settings.dry_run_mode else 'dim'}]{settings.dry_run_mode}[/]
+        [bold]System Settings:[/bold]
+        • Safe Mode: [{'green' if settings.safe_mode else 'red'}]{settings.safe_mode}[/]
+        • Debug Mode: [{'yellow' if settings.debug_mode else 'dim'}]{settings.debug_mode}[/]
+        • Dry Run: [{'yellow' if settings.dry_run_mode else 'dim'}]{settings.dry_run_mode}[/]
 
-[bold]Directories:[/bold]
-• Data: [dim]{settings.data_dir}[/dim]
-• Config: [dim]{settings.config_dir}[/dim]
-"""
+        [bold]Directories:[/bold]
+        • Data: [dim]{settings.data_dir}[/dim]
+        • Config: [dim]{settings.config_dir}[/dim]
+        """
     console.print(config_details)
 
 

--- a/src/oscar/config/settings.py
+++ b/src/oscar/config/settings.py
@@ -85,24 +85,24 @@ class OSCARSettings:
             },
             "system_prompt": """You are OSCAR, an intelligent system automation assistant. You help users accomplish tasks by creating structured, safe plans.
 
-Rules:
-1. Always respond with valid JSON containing: thoughts, plan, risk_level, confirm_prompt
-2. Break complex tasks into clear, sequential steps
-3. Each step should have: id, tool, command/action, explanation
-4. Risk levels: low, medium, high, dangerous
-5. Be conservative with risk assessment
-6. Include clear explanations for each step
+            Rules:
+            1. Always respond with valid JSON containing: thoughts, plan, risk_level, confirm_prompt
+            2. Break complex tasks into clear, sequential steps
+            3. Each step should have: id, tool, command/action, explanation
+            4. Risk levels: low, medium, high, dangerous
+            5. Be conservative with risk assessment
+            6. Include clear explanations for each step
 
-Available tools: shell, browser, file_ops
+            Available tools: shell, browser, file_ops
 
-Current OS: {os_type}
-Current working directory: {cwd}""",
-            
-            "planning_template": """User request: {user_input}
+            Current OS: {os_type}
+            Current working directory: {cwd}""",
+                        
+                        "planning_template": """User request: {user_input}
 
-Context from previous actions: {context}
+            Context from previous actions: {context}
 
-Create a structured plan to accomplish this request safely. Consider the user's operating system and current context."""
+            Create a structured plan to accomplish this request safely. Consider the user's operating system and current context."""
         }
         
         with open(config_path, 'w', encoding='utf-8') as f:
@@ -157,22 +157,19 @@ settings = OSCARSettings()
 # Centralized safety patterns (used by all components)
 SAFETY_PATTERNS = {
     "dangerous_commands": [
-        r"rm\s+-rf\s+/",
-        r"del\s+/s\s+/q", 
-        r"format\s+c:",
-        r"dd\s+if=",
-        r":(){ :|:& };:",  # Fork bomb
-        r"sudo\s+rm\s+-rf",
-        r"diskpart",
-        r"fdisk"
+        r"\brm\s+-rf\s+/.*",               # Remove root dir
+        r"\bdel\s+/s\s+/q\b",              # Windows delete
+        r"\bformat\s+c:\b",                # Format drive
+        r"\bdd\s+if=.*",                   # Disk overwrite
+        r":\(\)\s*\{\s*:\|\s*:\s*;\s*\}\s*;",  # Fork bomb
+        r"\bsudo\s+rm\s+-rf\s+/.*",        # Sudo rm -rf /
+        r"\bdiskpart\b",                   # Diskpart tool
+        r"\bfdisk\b"                       # fdisk tool
     ],
-    
     "high_risk_keywords": [
-        "sudo", "administrator", "registry", "system32",
-        "delete", "format", "partition", "boot"
+        "shutdown", "reboot", "mkfs", "chmod 777", "chown root"
     ],
-    
     "medium_risk_keywords": [
-        "install", "uninstall", "modify", "download", "execute"
+        "kill", "service stop", "systemctl stop", "rmdir", "mv /"
     ]
 }

--- a/src/oscar/core/agent.py
+++ b/src/oscar/core/agent.py
@@ -78,7 +78,7 @@ class OSCARAgent:
             console.print("[green]✓[/green] Plan generated successfully")
             
             # Stage 2: Safety Analysis & Confirmation
-            console.print("\n🛡️  [bold yellow]Safety Analysis...[/bold yellow]")
+            # console.print("\n🛡️  [bold yellow]Safety Analysis...[/bold yellow]")
             result["stage"] = "safety"
             
             approved, safety_report = analyze_and_confirm_plan(plan)
@@ -93,7 +93,7 @@ class OSCARAgent:
             console.print("[green]✓[/green] Plan approved by user")
             
             # Stage 3: Execution
-            console.print("\n⚙️  [bold green]Execution...[/bold green]")
+            console.print("\n⚙️  [bold green]Executing...[/bold green]")
             result["stage"] = "execution"
             
             execution_result = self._execute_plan(plan)

--- a/src/oscar/core/safety.py
+++ b/src/oscar/core/safety.py
@@ -88,11 +88,9 @@ class SafetyScanner:
         """Display the plan with safety analysis."""
         # Plan title with risk level
         risk_color = self.risk_colors[analysis["overall_risk"]]
-        title_text = Text()
-        title_text.append("📋 Execution Plan", style="bold blue")
-        title_text.append(f" (Risk: {analysis['overall_risk'].upper()})", style=f"bold {risk_color}")
-        
-        console.print(Panel(title_text, border_style=risk_color))
+
+        console.print()
+        console.rule()
         
         # Agent reasoning
         console.print(f"\n🤔 [bold]Agent Reasoning:[/bold]\n{plan.thoughts}\n")
@@ -121,7 +119,8 @@ class SafetyScanner:
             )
         
         console.print(table)
-        
+        console.print()
+        console.rule()
         # Safety flags
         if analysis["safety_flags"]:
             console.print("\n🚨 [bold red]Safety Flags:[/bold red]")
@@ -130,9 +129,9 @@ class SafetyScanner:
         
         # Simple recommendations
         if analysis["overall_risk"] == "dangerous":
-            console.print("\n⚠️  [bold red]DANGER: This plan contains potentially destructive operations[/bold red]")
+            console.print("\n ⚠️  [bold red]DANGER: This plan contains potentially destructive operations[/bold red]")
         elif analysis["overall_risk"] == "high":
-            console.print("\n⚠️  [bold yellow]HIGH RISK: Review each step carefully[/bold yellow]")
+            console.print("\n ⚠️  [bold yellow]HIGH RISK: Review each step carefully[/bold yellow]")
         
         if analysis["requires_admin"]:
             console.print("🔑  Administrative privileges required")


### PR DESCRIPTION
fix(safety): apply reasoning_effort only for GPT-OSS & update SAFETY_PATTERNS

- Restricted `reasoning_effort` parameter to apply only when model name is `gpt-oss`
- Updated `SAFETY_PATTERNS` in settings.py to improve detection of high-risk and medium-risk cases